### PR TITLE
Increase length of node description

### DIFF
--- a/src/zmime_editor_w3.prog.abap
+++ b/src/zmime_editor_w3.prog.abap
@@ -40,11 +40,7 @@ DATA: gv_ok_code   LIKE sy-ucomm,
       go_editor    TYPE REF TO cl_gui_abapedit,
       gs_smim      TYPE ty_smim.
 
-TYPES BEGIN OF ty_node.
-INCLUDE STRUCTURE treev_node.
-TYPES: text TYPE text50,
-  END OF ty_node.
-
+TYPES ty_node TYPE treesnode.
 TYPES ty_nodes TYPE STANDARD TABLE OF ty_node WITH KEY node_key.
 
 PARAMETERS p_devc TYPE devclass MEMORY ID dvc OBLIGATORY.

--- a/src/zmime_editor_w3_c01.prog.abap
+++ b/src/zmime_editor_w3_c01.prog.abap
@@ -96,7 +96,7 @@ CLASS lcl_tree_content IMPLEMENTATION.
 
     go_tree->add_nodes(
       EXPORTING
-        table_structure_name           = 'MTREESNODE'
+        table_structure_name           = 'TREESNODE'
         node_table                     = lt_nodes
       EXCEPTIONS
         failed                         = 1


### PR DESCRIPTION
Allow longer descriptions (char 50 to 80 to match `wwwdata-text`)